### PR TITLE
Add ability to apply scroll prompt to components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # adapt-scrollPrompt
 
-A button which can be appended to menu and/or page headers.
+A button which can be appended to menu, page headers, and/or components.
 
 Scroll prompt adds a visual aid to guide users as well as auto scroll functionality.
 

--- a/example.json
+++ b/example.json
@@ -1,5 +1,6 @@
   // apply to course.json for menu header
   // apply to contentObject.json for page header
+  // apply to components.json for component
   "_scrollPrompt": {
     "_isEnabled": true,
     "instruction": "Scroll down"

--- a/js/adapt-scrollPrompt.js
+++ b/js/adapt-scrollPrompt.js
@@ -37,6 +37,9 @@ define(function(require) {
 				Adapt.scrollTo('.js-children', { duration: 800 });
 			} else if (type === 'page'){
 				Adapt.scrollTo('.article', { duration: 800 });
+			} else if (type === 'component'){
+				var $nextBlock = this.$el.parents('.block').next();
+				Adapt.scrollTo($nextBlock, { duration: 800 });
 			}
 		}
 
@@ -44,7 +47,7 @@ define(function(require) {
 
 	Adapt.on('app:dataReady', function() {
 
-		Adapt.on('menuView:ready pageView:ready', function(view) {
+		Adapt.on('menuView:ready pageView:ready componentView:postRender', function(view) {
 
 			var model = view.model;
 
@@ -59,6 +62,10 @@ define(function(require) {
 					break;
 				case "course":
 					modelType = "menu";
+					break;
+				case "component":
+					modelType = "component";
+					break;
 			}
 			/* set model type selector to append scroll prompt */
 			var modelTypeSelector = '.' + modelType + '__header-inner';


### PR DESCRIPTION
This adds the ability for the scroll button to appear in components.  Useful when using a Text component in lieu of a page header, such as when this 'page header' block is using the Video Background extension.