### PR TITLE
New: Allow custom icon per prompt (fixes #19)

### DIFF
--- a/example.json
+++ b/example.json
@@ -1,6 +1,7 @@
   // Apply to course.json, contentObject.json, blocks.json or components.json
-  
+
   "_scrollPrompt": {
     "_isEnabled": true,
-    "instruction": "{{_globals._extensions._scrollPrompt.scrollDown}}"
+    "instruction": "{{_globals._extensions._scrollPrompt.scrollDown}}",
+    "_iconClass": "icon-controls-down"
   }

--- a/less/scrollPrompt.less
+++ b/less/scrollPrompt.less
@@ -6,15 +6,7 @@
     align-items: center;
   }
 
-  &__btn .icon {
-    .icon-controls-down;
-  }
-
   &__instruction {
-    margin-left: 1rem;
-    .dir-rtl & {
-      margin-left: inherit;
-      margin-right: 1rem;
-    }
+    margin-inline-start: 1rem;
   }
 }

--- a/properties.schema
+++ b/properties.schema
@@ -35,6 +35,15 @@
                   "inputType": "Text",
                   "validators": [],
                   "translatable": true
+                },
+                "_iconClass": {
+                  "type": "string",
+                  "required": false,
+                  "default": "icon-controls-down",
+                  "title": "Button icon class",
+                  "inputType": "Text",
+                  "validators": [],
+                  "help": "CSS class name to be applied to the scroll prompt button icon."
                 }
               }
             }
@@ -60,6 +69,15 @@
                   "inputType": "Text",
                   "validators": [],
                   "translatable": true
+                },
+                "_iconClass": {
+                  "type": "string",
+                  "required": false,
+                  "default": "icon-controls-down",
+                  "title": "Button icon class",
+                  "inputType": "Text",
+                  "validators": [],
+                  "help": "CSS class name to be applied to the scroll prompt button icon."
                 }
               }
             }
@@ -85,6 +103,15 @@
                   "inputType": "Text",
                   "validators": [],
                   "translatable": true
+                },
+                "_iconClass": {
+                  "type": "string",
+                  "required": false,
+                  "default": "icon-controls-down",
+                  "title": "Button icon class",
+                  "inputType": "Text",
+                  "validators": [],
+                  "help": "CSS class name to be applied to the scroll prompt button icon."
                 }
               }
             }
@@ -110,6 +137,15 @@
                   "inputType": "Text",
                   "validators": [],
                   "translatable": true
+                },
+                "_iconClass": {
+                  "type": "string",
+                  "required": false,
+                  "default": "icon-controls-down",
+                  "title": "Button icon class",
+                  "inputType": "Text",
+                  "validators": [],
+                  "help": "CSS class name to be applied to the scroll prompt button icon."
                 }
               }
             }

--- a/schema/block.schema.json
+++ b/schema/block.schema.json
@@ -24,6 +24,12 @@
               "type": "string",
               "title": "Instruction text",
               "default": "{{_globals._extensions._scrollPrompt.scrollDown}}"
+            },
+            "_iconClass": {
+              "type": "string",
+              "title": "Button icon class",
+              "description": "CSS class name to be applied to the scroll prompt button icon.",
+              "default": "icon-controls-down"
             }
           }
         }

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -24,6 +24,12 @@
               "type": "string",
               "title": "Instruction text",
               "default": "{{_globals._extensions._scrollPrompt.scrollDown}}"
+            },
+            "_iconClass": {
+              "type": "string",
+              "title": "Button icon class",
+              "description": "CSS class name to be applied to the scroll prompt button icon.",
+              "default": "icon-controls-down"
             }
           }
         }

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -24,6 +24,12 @@
               "type": "string",
               "title": "Instruction text",
               "default": "{{_globals._extensions._scrollPrompt.scrollDown}}"
+            },
+            "_iconClass": {
+              "type": "string",
+              "title": "Button icon class",
+              "description": "CSS class name to be applied to the scroll prompt button icon.",
+              "default": "icon-controls-down"
             }
           }
         }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -51,6 +51,12 @@
               "type": "string",
               "title": "Instruction text",
               "default": "{{_globals._extensions._scrollPrompt.scrollDown}}"
+            },
+            "_iconClass": {
+              "type": "string",
+              "title": "Button icon class",
+              "description": "CSS class name to be applied to the scroll prompt button icon.",
+              "default": "icon-controls-down"
             }
           }
         }

--- a/templates/scrollPrompt.jsx
+++ b/templates/scrollPrompt.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { compile } from 'core/js/reactHelpers';
+import { classes, compile } from 'core/js/reactHelpers';
 
 export default function ScrollPrompt (props) {
   const {
@@ -8,14 +8,33 @@ export default function ScrollPrompt (props) {
   } = props;
 
   return (
-    <div className="scrollPrompt__inner a11y-ignore" aria-hidden="true">
-      <button className="btn-icon scrollPrompt__btn" onClick={onScrollPromptClick}>
-        <span className="icon" />
+    <div
+      className='scrollPrompt__inner a11y-ignore'
+      aria-hidden='true'
+    >
+
+      <button
+        className='btn-icon scrollPrompt__btn'
+        onClick={onScrollPromptClick}
+      >
+        <span
+          className={classes([
+            'icon',
+            _scrollPrompt._iconClass
+              ? _scrollPrompt._iconClass
+              : 'icon-controls-down'
+          ])}
+          aria-hidden='true'
+        />
       </button>
 
       {_scrollPrompt.instruction &&
-      <div className="scrollPrompt__instruction" dangerouslySetInnerHTML={{ __html: compile(_scrollPrompt.instruction, props) }} />
+      <div
+        className='scrollPrompt__instruction'
+        dangerouslySetInnerHTML={{ __html: compile(_scrollPrompt.instruction, props) }}
+      />
       }
+
     </div>
   );
 }


### PR DESCRIPTION
Fixes: #19 

### New
* Added a new config option `_iconClass`
* If `_iconClass` is not defined it uses the default value of `icon-controls-down`
* Changing the value of `_iconClass` changes the class applied to the icon
* The value of `_iconClass` must be a predefined icon, detailed on the [Vanilla Wiki](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Icons)
