### PR TITLE
Fix: Scroll fails if next block is in different article (fix #29)

### DIFF
--- a/js/ScrollPromptView.js
+++ b/js/ScrollPromptView.js
@@ -2,6 +2,7 @@ import Adapt from 'core/js/adapt';
 import Router from 'core/js/router';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import logging from 'core/js/logging';
 import { templates } from 'core/js/reactHelpers';
 
 export default class ScrollPromptView extends Backbone.View {
@@ -33,16 +34,30 @@ export default class ScrollPromptView extends Backbone.View {
     this.listenTo(Adapt, 'remove', this.remove);
   }
 
-  onScrollPromptClick(e) {
-    // Set scroll to selector based on model type
+  getNextBlock() {
+    const currentBlock = this.$el.parents('.block');
+    const nextSibling = currentBlock.next('.block');
+    if (nextSibling.length) return nextSibling;
+    return currentBlock.parents('.article').next('.article').find('.block').first();
+  }
+
+  getTarget(type) {
+    switch (type) {
+      case 'course': return '.js-children';
+      case 'page': return '.article';
+      case 'block':
+      case 'component': return this.getNextBlock();
+    }
+  }
+
+  onScrollPromptClick() {
     const type = this.model.get('_type');
-    const nextEl = {
-      course: '.js-children',
-      page: '.article',
-      block: this.$el.parents('.block').next(),
-      component: this.$el.parents('.block').next()
-    };
-    Router.navigateToElement(nextEl[type], { duration: 800 });
+    const target = this.getTarget(type);
+    if (target instanceof $ && !target.length) {
+      logging.warn(`scrollPrompt: no next element found for type ${type} on ${this.model.get('_id')}`);
+      return;
+    }
+    Router.navigateToElement(target, { duration: 800 });
   }
 
 };

--- a/js/ScrollPromptView.js
+++ b/js/ScrollPromptView.js
@@ -2,6 +2,7 @@ import Adapt from 'core/js/adapt';
 import Router from 'core/js/router';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import logging from 'core/js/logging';
 import { templates } from 'core/js/reactHelpers';
 
 export default class ScrollPromptView extends Backbone.View {
@@ -33,16 +34,34 @@ export default class ScrollPromptView extends Backbone.View {
     this.listenTo(Adapt, 'remove', this.remove);
   }
 
-  onScrollPromptClick(e) {
-    // Set scroll to selector based on model type
+  getNextBlock() {
+    const currentBlock = this.$el.parents('.block');
+    const nextSibling = currentBlock.next('.block');
+    if (nextSibling.length) return nextSibling;
+    return currentBlock.parents('.article').next('.article').find('.block').first();
+  }
+
+  getTarget(type) {
+    switch (type) {
+      case 'course': return '.js-children';
+      case 'page': return '.article';
+      case 'block':
+      case 'component': return this.getNextBlock();
+      default:
+        logging.warn(`scrollPrompt: unknown type "${type}" on ${this.model.get('_id')}`);
+        return null;
+    }
+  }
+
+  onScrollPromptClick() {
     const type = this.model.get('_type');
-    const nextEl = {
-      course: '.js-children',
-      page: '.article',
-      block: this.$el.parents('.block').next(),
-      component: this.$el.parents('.block').next()
-    };
-    Router.navigateToElement(nextEl[type], { duration: 800 });
+    const target = this.getTarget(type);
+    if (target == null) return;
+    if (target instanceof $ && !target.length) {
+      logging.warn(`scrollPrompt: no next element found for type ${type} on ${this.model.get('_id')}`);
+      return;
+    }
+    Router.navigateToElement(target, { duration: 800 });
   }
 
 };

--- a/js/adapt-scrollPrompt.js
+++ b/js/adapt-scrollPrompt.js
@@ -15,10 +15,13 @@ class ScrollPrompt extends Backbone.Controller {
     const scrollPrompt = model.get('_scrollPrompt');
     if (!scrollPrompt || !scrollPrompt._isEnabled) return;
 
-    let type = model.get('_type');
-    if (type === 'course') type = 'menu';
-    const suffix = ['component', 'block'].includes(type) ? '__inner' : '__header-inner';
-    const selector = `.${type}${suffix}`;
+    const selectorByType = {
+      course: '.menu__header-inner',
+      page: '.page__header-inner',
+      block: '.block__inner',
+      component: '.component__inner'
+    };
+    const selector = selectorByType[model.get('_type')];
 
     new ScrollPromptView({
       model


### PR DESCRIPTION
Fix #29 

### Fix
* When block is the last child in an article, allow it to scroll to the next block in the next article.
* Refactor selector in setupView() for clarity
